### PR TITLE
feat: rework networks input

### DIFF
--- a/packages/plugin/src/MultichainHardhatRuntimeEnvironmentField.ts
+++ b/packages/plugin/src/MultichainHardhatRuntimeEnvironmentField.ts
@@ -1,6 +1,5 @@
 import { Artifact, HardhatRuntimeEnvironment } from "hardhat/types";
 import { Config, Domain } from "@buildwithsygma/sygma-sdk-core";
-import { HardhatPluginError } from "hardhat/plugins";
 import Web3, {
   ContractAbi,
   Transaction,
@@ -10,7 +9,6 @@ import Web3, {
 } from "web3";
 import {
   getConfigEnvironmentVariable,
-  getDeploymentNetworks,
   getNetworkChainId,
   mapNetworkArgs,
   sumedFees,
@@ -44,30 +42,6 @@ export class MultichainHardhatRuntimeEnvironmentField {
     await config.init(originChainId, environment);
 
     this.domains = config.getDomains();
-    const domainChainIds = this.domains.map(({ chainId }) => chainId);
-
-    const deploymentNetworks = getDeploymentNetworks(this.hre);
-    const deploymentNetworksInfo = await Promise.all(
-      deploymentNetworks.map(async (name) => {
-        const chainId = await getNetworkChainId(name, this.hre);
-        return { name, chainId };
-      })
-    );
-
-    const missedRoutes: typeof deploymentNetworksInfo = [];
-    deploymentNetworksInfo.forEach(({ chainId, name }) => {
-      if (!domainChainIds.includes(chainId))
-        missedRoutes.push({ chainId, name });
-    });
-    if (missedRoutes.length)
-      throw new HardhatPluginError(
-        "@chainsafe/hardhat-plugin-multichain-deploy",
-        `Unavailable Networks in Deployment: The following networks from 'deploymentNetworks' are not routed in Sygma for the '${environment}' environment: ${missedRoutes
-          .map(({ chainId, name }) => `${name}(${chainId})`)
-          .join(", ")
-          .replace(/, ([^,]*)$/, " and $1")}\n` +
-          `Please adjust your 'deploymentNetworks' to align with the supported routes in this environment. For details on supported networks, refer to the Sygma documentation.`
-      );
 
     this.isValidated = true;
   }

--- a/packages/plugin/src/index.ts
+++ b/packages/plugin/src/index.ts
@@ -1,5 +1,5 @@
 import { extendConfig, extendEnvironment } from "hardhat/config";
-import { HardhatPluginError, lazyObject } from "hardhat/plugins";
+import { lazyObject } from "hardhat/plugins";
 import {
   HardhatConfig,
   HardhatUserConfig,
@@ -22,33 +22,6 @@ extendConfig(
       );
       multichainConfig.environment = Environment.TESTNET;
     }
-
-    if (
-      !multichainConfig.deploymentNetworks ||
-      !multichainConfig.deploymentNetworks.length
-    ) {
-      console.warn(
-        "Warning: Missing Deployment Networks - It appears that you have not provided the Deployment Networks. To avoid potential issues, it is recommended that you supply these values. If they are not provided, you will be required to enter them manually as parameters. Please ensure that the necessary information is included to facilitate a smoother process."
-      );
-      multichainConfig.deploymentNetworks = [];
-    }
-
-    /** Validates that all networks in 'deploymentNetworks' are defined in 'config.networks'. */
-    const missedNetworks: string[] = [];
-    const configNetworkKeys = Object.keys(config.networks);
-    multichainConfig.deploymentNetworks.forEach((networkName) => {
-      if (!configNetworkKeys.includes(networkName))
-        missedNetworks.push(networkName);
-    });
-    if (missedNetworks.length)
-      throw new HardhatPluginError(
-        "@chainsafe/hardhat-plugin-multichain-deploy",
-        `Missing Configuration for Deployment Networks: ${missedNetworks
-          .join(", ")
-          .replace(/, ([^,]*)$/, " and $1")}\n` +
-          `The above networks are listed in your 'deploymentNetworks' but they are not defined in 'config.networks'. ` +
-          `Please ensure each of these networks is properly configured in the 'config.networks' section of your configuration.`
-      );
 
     config.multichain = multichainConfig as MultichainConfig;
   }

--- a/packages/plugin/src/type-extensions.ts
+++ b/packages/plugin/src/type-extensions.ts
@@ -11,7 +11,6 @@ declare module "hardhat/types/config" {
 
   export interface MultichainConfig {
     environment: Environment;
-    deploymentNetworks: string[];
   }
 
   export interface HardhatUserConfig {

--- a/packages/plugin/src/utils.ts
+++ b/packages/plugin/src/utils.ts
@@ -41,12 +41,6 @@ export async function getNetworkChainId(
   return chainID;
 }
 
-export function getDeploymentNetworks(
-  hre: HardhatRuntimeEnvironment
-): string[] {
-  return hre.config.multichain.deploymentNetworks;
-}
-
 export function sumedFees(fees: Numbers[]): string {
   const sumOfFees = fees.reduce(
     (previous, current) => BigInt(previous) + BigInt(current),
@@ -79,7 +73,7 @@ export function mapNetworkArgs<Abi extends ContractAbi = any>(
   const initDatas: Bytes[] = [];
 
   Object.keys(networkArgs).map((networkName) => {
-    //checks if network args
+    //checks if destination networks name is valid
     const matchingDomain = domains.find(
       (domain) => domain.name === networkName
     );
@@ -87,7 +81,12 @@ export function mapNetworkArgs<Abi extends ContractAbi = any>(
     else {
       throw new HardhatPluginError(
         "@chainsafe/hardhat-plugin-multichain-deploy",
-        `Unavailable Networks in networkArgs: The following network ${networkName} is not supported as destination network.`
+        `Unavailable Networks in networkArgs: The following network ${networkName} is not supported as destination network.
+        Available networks: ${domains
+          .map((domain): string => `${domain.name}`)
+          .join(", ")
+          .replace(/, ([^,]*)$/, "")}\n
+        `
       );
     }
 

--- a/packages/plugin/test/fixture-projects/hardhat-project/hardhat.config.ts
+++ b/packages/plugin/test/fixture-projects/hardhat-project/hardhat.config.ts
@@ -19,7 +19,6 @@ const config: HardhatUserConfig = {
   },
   multichain: {
     environment: Environment.TESTNET,
-    deploymentNetworks: ["sepolia"],
   },
 };
 

--- a/packages/plugin/test/project.test.ts
+++ b/packages/plugin/test/project.test.ts
@@ -24,13 +24,6 @@ describe("Integration tests examples", function () {
   describe("HardhatConfig extension", function () {
     useEnvironment("hardhat-project");
 
-    it("Should add the multichain.deploymentNetworks to the config", function () {
-      assert.deepEqual(
-        this.hre.config.multichain.deploymentNetworks,
-        ["sepolia"]
-      );
-    });
-
     it("Should add the multichain.environment to the config", function () {
       assert.deepEqual(
         this.hre.config.multichain.environment,


### PR DESCRIPTION
config no longer takes destination networks, all destination networks are in deployMultichain methods

Closes #20 