### PR TITLE
chore: example revert on destination chains

### DIFF
--- a/example/scripts/deployMultichain.ts
+++ b/example/scripts/deployMultichain.ts
@@ -3,7 +3,7 @@ import { NetworkArguments } from "@chainsafe/hardhat-plugin-multichain-deploy";
 
 async function main(): Promise<void> {
   const currentTimestampInSeconds = Math.round(Date.now() / 1000);
-  const unlockTime = BigInt(currentTimestampInSeconds + 60);
+  const unlockTime = BigInt(currentTimestampInSeconds + 1200);
   const [deployer] = await web3.eth.getAccounts();
 
   const networkArguments: NetworkArguments = {

--- a/example/scripts/deployMultichainBytecode.ts
+++ b/example/scripts/deployMultichainBytecode.ts
@@ -4,7 +4,7 @@ import artifact from "../artifacts/contracts/Lock.sol/Lock";
 
 async function main(): Promise<void> {
   const currentTimestampInSeconds = Math.round(Date.now() / 1000);
-  const unlockTime = BigInt(currentTimestampInSeconds + 60);
+  const unlockTime = BigInt(currentTimestampInSeconds + 1200);
   const [deployer] = await web3.eth.getAccounts();
 
   const networkArguments: NetworkArguments = {

--- a/example/scripts/localhost.ts
+++ b/example/scripts/localhost.ts
@@ -3,7 +3,7 @@ import { NetworkArguments } from "@chainsafe/hardhat-plugin-multichain-deploy";
 
 async function main(): Promise<void> {
   const currentTimestampInSeconds = Math.round(Date.now() / 1000);
-  const unlockTime = BigInt(currentTimestampInSeconds + 60);
+  const unlockTime = BigInt(currentTimestampInSeconds + 1200);
   const [deployer] = await web3.eth.getAccounts();
 
   const { adapterAddress } = await multichain.initLocalEnvironment();


### PR DESCRIPTION
Thanks to Tim for finding it!

It reverted on destination chains as the timestamp went to past time.
```sol
constructor(address _owner, uint _unlockTime) payable {
        require(
            block.timestamp < _unlockTime,
            "Unlock time should be in the future"
        );

        unlockTime = _unlockTime;
        owner = payable(_owner);
    }
```